### PR TITLE
Add warning that DB password can't be empty in docs + fix typo

### DIFF
--- a/docs/server-docs/setup/docker-compose.md
+++ b/docs/server-docs/setup/docker-compose.md
@@ -49,7 +49,11 @@ services:
 ```
 
 :::note
-Replace the the variables (`YOURPASSWORDHERE`, `YOURAPIKEYHERE`, `etc.`), as well as the folder paths with what suits you, of course.
+Replace the variables (`YOURPASSWORDHERE`, `YOURAPIKEYHERE`, `etc.`), as well as the folder paths with what suits you, of course.
+:::
+
+:::warning
+Password (YOURPASSWORDHERE) can't be empty! else the database will not work. If you don't want a password, consider running without a PostgreSQL Database (Not recommended)
 :::
 
 ### Alternative Step 1: Running without a PostgreSQL Database


### PR DESCRIPTION
Fixes a typo (double "the") and adds a warning mentioning that the DB's password can't be empty